### PR TITLE
get the request and response from the app container

### DIFF
--- a/src/Lib/Connector/Slim.php
+++ b/src/Lib/Connector/Slim.php
@@ -69,7 +69,6 @@ final class Slim extends Client
         $slimResponse = $this->app->process(
             $slimRequest,
             $container->get('response')
-              ->withProtocolVersion($container->get('settings')['httpVersion'])
               ->withBody(new Stream(fopen('php://temp', 'w+')))
         );
 

--- a/tests/functional/RequestAndResponseAreFromContainerCept.php
+++ b/tests/functional/RequestAndResponseAreFromContainerCept.php
@@ -1,0 +1,12 @@
+<?php
+$I = new FunctionalTester($scenario);
+
+$I->wantTo('test that the request and response objects are being created from the container');
+$I->haveHttpHeader('content-type', 'application/json');
+$I->sendPOST('/rest');
+$I->seeResponseCodeIs(\Codeception\Util\HttpCode::OK);
+$I->seeResponseContainsJson([
+  'responseClass' => 'NewResponse',
+  'requestClass' => 'NewRequest',
+]);
+


### PR DESCRIPTION
I'd like to see if we can figure out how to refactor the 

```
Request::createFromEnvironment($environment)
```

on line 46 into just

```
$container->get('request')
```
